### PR TITLE
Refactoring - Move files and directories while updating import paths automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Angular Mode offers convenient shortcuts to quickly open files for various Angul
 
 ### Jump Between Corresponding Files
 
-Angular Mode provides an easy way to help you jump between associated Angular files with ease. Whether you're working with components, services, or other Angular schematics, you can quickly switch between the following file types:
+Angular Mode provides an easy way to help you jump between associated Angular files with ease. Whether you're working with components, services, resolvers, etc., you can quickly switch between the following file types:
 
 - **Template**: Jump to the associated `.html` file - `C-c a o t`
 - **Component**: Jump to the associated `.ts` file - `C-c a o c`
@@ -60,7 +60,7 @@ Angular Mode provides an easy way to help you jump between associated Angular fi
 
 Tired of manually updating import paths when moving files around and wasting a bunch of time? Me too!
 
-Now you can do it in seconds by using `M-x angular-refactor-move-directory` to move an entire directory of angular files or `M-x angular-refactor-move-entity` to move a specific file (and associated spec file if it exists) to the destination of your choosing.
+Now you can do it in seconds by using `M-x angular-refactor-move-directory` (`C-c a r d`) to move an entire directory of angular files or `M-x angular-refactor-move-entity` (`C-c a r e`) to move a specific file (and associated spec file if it exists) to the destination of your choosing.
 
 Upon move, every import path that references the moved files will automatically update to the new path. If you have a preference on using `relative` vs. `absolute`, you can customize `angular-import-path-style` (defaults to `relative`) by using the customize interface or by adding this to your config:
 
@@ -68,9 +68,7 @@ Upon move, every import path that references the moved files will automatically 
 (setopt angular-import-path-style 'absolute)
 ```
 
-Simply `C-c a r d` `C-c a r e` to
-
-**Note**: The refactor move functions do not support custom modules. I will look into adding support for this.
+**Note**: The refactor move functions do not support custom modules. This means any import path that references a custom module will not be updated.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,28 +4,30 @@ Angular Mode enhances your workflow by providing an interactive API for Angular 
 
 ## Keybindings
 
-| Keybinding  | Command Description                                                  | Command                             |
-|-------------|----------------------------------------------------------------------|-------------------------------------|
-| `C-c a g`   | Generate an Angular Schematic.                                       | `angular-generate`                  |
-| `C-c a o c` | Open a `component.ts` file.                                          | `angular-open-component`            |
-| `C-c a o t` | Open a `component.html` file.                                        | `angular-open-component-template`   |
-| `C-c a o v` | Open a `component.(scss\|sass\|less\|css)` file.                     | `angular-open-component-stylesheet` |
-| `C-c a o x` | Open a `component.spec.ts` file.                                     | `angular-open-component-test`       |
-| `C-c a o d` | Open a `directive.ts` file.                                          | `angular-open-directive`            |
-| `C-c a o g` | Open a `guard.ts` file.                                              | `angular-open-guard`                |
-| `C-c a o i` | Open a `interceptor.ts` file.                                        | `angular-open-interceptor`          |
-| `C-c a o m` | Open a `module.ts` file.                                             | `angular-open-module`               |
-| `C-c a o p` | Open a `pipe.ts` file.                                               | `angular-open-pipe`                 |
-| `C-c a o r` | Open a `resolver.ts` file.                                           | `angular-open-resolver`             |
-| `C-c a o s` | Open a `service.ts` file.                                            | `angular-open-service`              |
-| `C-c a o w` | Open a `worker.ts` file.                                             | `angular-open-web-worker`           |
-| `C-c a j c` | Jump to corresponding `component.ts` file.                           | `angular-jump-to-component`         |
-| `C-c a j t` | Jump to corresponding `component.html` file.                         | `angular-jump-to-template`          |
-| `C-c a j v` | Jump to corresponding `component.(scss\|sass\|less\|css)` file.      | `angular-jump-to-stylesheet`        |
-| `C-c a j x` | Jump to corresponding `component.spec.ts` file.                      | `angular-jump-to-test`              |
-| `C-c a p`   | Open the project's `angular.json` file.                              | `angular-project-config`            |
-| `C-c a h d` | Lookup current word at point in API reference documentation website. | `angular-lookup-word`               |
-| `C-c a h s` | Perform a search of angular.io using the current word at point.      | `angular-search-word`               |
+| Keybinding  | Command Description                                                                                   | Command                             |
+|-------------|-------------------------------------------------------------------------------------------------------|-------------------------------------|
+| `C-c a g`   | Generate an Angular Schematic.                                                                        | `angular-generate`                  |
+| `C-c a o c` | Open a `component.ts` file.                                                                           | `angular-open-component`            |
+| `C-c a o t` | Open a `component.html` file.                                                                         | `angular-open-component-template`   |
+| `C-c a o v` | Open a `component.(scss\|sass\|less\|css)` file.                                                      | `angular-open-component-stylesheet` |
+| `C-c a o x` | Open a `component.spec.ts` file.                                                                      | `angular-open-component-test`       |
+| `C-c a o d` | Open a `directive.ts` file.                                                                           | `angular-open-directive`            |
+| `C-c a o g` | Open a `guard.ts` file.                                                                               | `angular-open-guard`                |
+| `C-c a o i` | Open a `interceptor.ts` file.                                                                         | `angular-open-interceptor`          |
+| `C-c a o m` | Open a `module.ts` file.                                                                              | `angular-open-module`               |
+| `C-c a o p` | Open a `pipe.ts` file.                                                                                | `angular-open-pipe`                 |
+| `C-c a o r` | Open a `resolver.ts` file.                                                                            | `angular-open-resolver`             |
+| `C-c a o s` | Open a `service.ts` file.                                                                             | `angular-open-service`              |
+| `C-c a o w` | Open a `worker.ts` file.                                                                              | `angular-open-web-worker`           |
+| `C-c a j c` | Jump to corresponding `component.ts` file.                                                            | `angular-jump-to-component`         |
+| `C-c a j t` | Jump to corresponding `component.html` file.                                                          | `angular-jump-to-template`          |
+| `C-c a j v` | Jump to corresponding `component.(scss\|sass\|less\|css)` file.                                       | `angular-jump-to-stylesheet`        |
+| `C-c a j x` | Jump to corresponding `component.spec.ts` file.                                                       | `angular-jump-to-test`              |
+| `C-c a r d` | Move a directory to a new destination and update import paths for all entities within the directory.  | `angular-refactor-move-directory`   |
+| `C-c a r e` | Move an entity and associated spec file to a new destination and update import paths for those files. | `angular-refactor-move-entity`      |
+| `C-c a p`   | Open the project's `angular.json` file.                                                               | `angular-project-config`            |
+| `C-c a h d` | Lookup current word at point in API reference documentation website.                                  | `angular-lookup-word`               |
+| `C-c a h s` | Perform a search of angular.io using the current word at point.                                       | `angular-search-word`               |
 
 **Note**: At the moment, Angular Mode only supports the `generate` commands.
 
@@ -39,20 +41,36 @@ Using the `C-c a g` command, you can perform the following:
 
 - Choose a schematic from the list.
 - Specify a name for the selected schematic.
-- Pick a destination directory for the generated schematic.
+- Pick a destination directory for the scaffolded file(s).
 
-### Quick Open Schematics
+### Quick Open Angular Files
 
-Angular Mode offers convenient shortcuts to quickly open files for various Angular schematics by using the `C-c a o` prefix. This will provide a filtered list of files based on the schematic type. See the list of corresponding [keybindings](#keybindings).
+Angular Mode offers convenient shortcuts to quickly open files for various Angular scaffolded files by using the `C-c a o` prefix. This will provide a filtered list of files based on the schematic type. See the list of corresponding [keybindings](#keybindings).
 
 ### Jump Between Corresponding Files
 
 Angular Mode provides an easy way to help you jump between associated Angular files with ease. Whether you're working with components, services, or other Angular schematics, you can quickly switch between the following file types:
 
-- **Template**: Jump to the associated `.html` file.
-- **Component**: Jump to the associated `.ts` file.
-- **Test**: Jump to the associated `.spec.ts` file.
-- **Stylesheet**: Jump to the associated `.scss`, `.less`, `.sass`, or `.css` file
+- **Template**: Jump to the associated `.html` file - `C-c a o t`
+- **Component**: Jump to the associated `.ts` file - `C-c a o c`
+- **Test**: Jump to the associated `.spec.ts` file - `C-c a o s`
+- **Stylesheet**: Jump to the associated `.scss`, `.less`, `.sass`, or `.css` file - `C-c a o v`
+
+### Moving Files and Directories
+
+Tired of manually updating import paths when moving files around and wasting a bunch of time? Me too!
+
+Now you can do it in seconds by using `M-x angular-refactor-move-directory` to move an entire directory of angular files or `M-x angular-refactor-move-entity` to move a specific file (and associated spec file if it exists) to the destination of your choosing.
+
+Upon move, every import path that references the moved files will automatically update to the new path. If you have a preference on using `relative` vs. `absolute`, you can customize `angular-import-path-style` (defaults to `relative`) by using the customize interface or by adding this to your config:
+
+```elisp
+(setopt angular-import-path-style 'absolute)
+```
+
+Simply `C-c a r d` `C-c a r e` to
+
+**Note**: The refactor move functions do not support custom modules. I will look into adding support for this.
 
 ## Installation
 

--- a/angular-mode.el
+++ b/angular-mode.el
@@ -89,7 +89,7 @@
     "ng")
   "Path to the Angular CLI executable.")
 
-(defcustom angular-import-path-style 'absolute
+(defcustom angular-import-path-style 'relative
   "Determines the style of import paths in Angular projects.
 Choose \\'absolute for absolute paths or \\'relative for relative paths."
   :type '(choice (const :tag "Absolute" absolute)
@@ -261,7 +261,6 @@ Optionally SEARCH the angular.io website."
 (defun angular-update-import-paths (old-path new-path)
   "Update import paths in TypeScript files from OLD-PATH to NEW-PATH."
   (let* ((project-root (find-angular-project-root))
-         ;; TODO Consider ignoring certain directories (ex. node_modules)  instead of using 'src/app'
          (app-directory (expand-file-name "src/app" project-root))
          (file-name (file-name-nondirectory old-path))
          (search (expand-file-name old-path project-root))
@@ -277,44 +276,111 @@ Optionally SEARCH the angular.io website."
 
         (let ((original-contents (buffer-string))
               (file-path (file-name-directory ts-file)))
-
           ;; Search through each import statement and replace path
           (while (re-search-forward import-regex nil t)
             (let ((match (match-string 2))) ; The matched import path
               (unless (string-prefix-p "@" match) ; TODO Add support for custom modules in future
-                (let ((expanded-match (expand-file-name match file-path)))
+                (let ((expanded-match
+                       ;; If the current 'file-path' ends in src/app/
+                       ;; and import begins with src/app, use 'project-root' as base expansion instead of 'file-path'
+                       (if (and (string-match-p "src/app" match) (string-match-p "src/app/$" file-path))
+                           (expand-file-name match project-root)
+                         (expand-file-name match file-path))))
                   (when (string-prefix-p search expanded-match)
                     (let* ((remainder (substring expanded-match (length search)))
-                           (final-replacement-path (cond
-                                                    ((eq angular-import-path-style 'absolute)
-                                                     (file-relative-name (concat (directory-file-name replace) remainder) project-root))
-                                                    ((eq angular-import-path-style 'relative)
-                                                     (let ((relative-path (file-relative-name (concat (directory-file-name replace) remainder) file-path)))
-                                                     ;; Ensure relative paths start with "./" if they don't already
-                                                     (if (or (string-prefix-p "./" relative-path) (string-prefix-p "../" relative-path))
-                                                         relative-path
-                                                       (concat "./" relative-path)))))))
-                      ;; Replace the matched text with the new relative path
+                           (final-replacement-path
+                            (cond
+                             ((eq angular-import-path-style 'absolute)
+                              (file-relative-name (concat (directory-file-name replace) remainder) project-root))
+                             ((eq angular-import-path-style 'relative)
+                              (let ((relative-path (file-relative-name
+                                                    (concat (directory-file-name replace) remainder) file-path)))
+                                ;; Ensure relative paths start with "./" if they don't already
+                                (if (or (string-prefix-p "./" relative-path) (string-prefix-p "../" relative-path))
+                                    relative-path
+                                  (concat "./" relative-path)))))))
+                      ;; Replace the matched text with the new path
                       (replace-match final-replacement-path nil nil nil 2)))))))
 
           (when (not (equal (buffer-string) original-contents))
             (write-region (point-min) (point-max) ts-file)))))))
 
-(defun angular-refactor-move-component (current-path destination)
-  "Move Angular component from CURRENT-PATH to DESTINATION, updating import paths."
-  (interactive (list (read-file-name "Current component path: ")
-                     (read-directory-name "New component directory: ")))
-  (let* ((current-dir (directory-file-name (file-name-directory current-path)))
-         (component-name (file-name-nondirectory (directory-file-name current-dir)))
-         (new-dir (expand-file-name component-name destination)))
+;;(defalias 'angular-refactor-move-component 'angular-refactor-move-directory)
+
+(defun angular-refactor-move-directory (current-directory destination)
+  "Move Angular component from 'CURRENT-DIRECTORY' to 'DESTINATION'.
+Update all import paths in files that reference the component."
+  (interactive (list (read-directory-name "Current directory: ")
+                     (read-directory-name "New directory: ")))
+  (let* ((current-dir (expand-file-name (directory-file-name (file-name-directory current-directory))))
+         (current-dir-name (file-name-nondirectory current-dir))
+         (new-dir (file-name-concat (expand-file-name (file-name-directory destination)) current-dir-name)))
     (when (file-directory-p new-dir)
-      (error "Destination already has a directory named '%s'" component-name))
+      (error "Destination already has a directory named '%s'" new-dir))
     (unless (file-directory-p destination)
       (make-directory destination :parents))
-    ;; (rename-file current-dir new-dir t) ; Uncomment after testing
+    (rename-file current-dir new-dir t)
     (angular-update-import-paths current-dir new-dir)
-    ;; (find-file new-dir)
     ))
+
+(defun angular-refactor-move-entity (current-path destination)
+  "Move Angular entity and associated spec file \\
+from 'CURRENT-PATH' to 'DESTINATION'.
+Update all import paths in files that reference the entity."
+
+  (interactive (list (read-file-name "Select entity: ")
+                     (read-directory-name "New directory: ")))
+
+  (let* ((is-spec-file (string-suffix-p (format ".spec.ts") current-path))
+         (base-name (file-name-sans-extension (file-name-nondirectory current-path)))
+         (base-path (file-name-directory current-path))
+         (current-dir (directory-file-name base-path))
+         (file-name (if is-spec-file
+                        (file-name-sans-extension (file-name-sans-extension (file-name-nondirectory current-path)))
+                      (file-name-sans-extension (file-name-nondirectory current-path))))
+         (spec-file-exists (or is-spec-file (file-exists-p (expand-file-name (concat base-name ".spec.ts") current-dir))))
+
+         (component-name (file-name-nondirectory (directory-file-name current-dir)))
+         (new-dir (expand-file-name component-name destination))
+
+         (full-name (file-name-nondirectory current-path))
+
+         (file-name-ext (if is-spec-file
+                            (concat file-name ".ts")
+                          full-name))
+         (old-base-path (expand-file-name file-name-ext base-path))
+         (new-base-path (expand-file-name file-name-ext destination))
+
+         (spec-name-ext (if is-spec-file
+                            full-name
+                          (concat base-name ".spec.ts")))
+
+         (old-spec-path (expand-file-name spec-name-ext base-path))
+         (new-spec-path (expand-file-name spec-name-ext destination))) ;; end let
+
+    (when (file-in-directory-p file-name-ext new-dir)
+      (error "Destination already has a file named '%s'" file-name-ext))
+
+    (when (and spec-file-exists (file-in-directory-p spec-name-ext new-dir))
+      (error "Destination already has a spec file named '%s'" file-name-ext))
+
+    ;; Create destination directory if it doesn't exist
+    (unless (file-directory-p destination)
+      (make-directory destination :parents))
+
+    ;; (unless is-spec-file
+    (rename-file old-base-path new-base-path t)
+
+    ;; Move the associated spec file if it exists
+    (when (or is-spec-file spec-file-exists)
+      (rename-file old-spec-path new-spec-path t))
+
+    ;; Update import paths for entity file
+    (angular-update-import-paths (file-name-sans-extension old-base-path) (file-name-sans-extension new-base-path))
+
+    ;; Update import paths for spec file
+    (when (or is-spec-file spec-file-exists)
+      (angular-update-import-paths (file-name-sans-extension old-spec-path) (file-name-sans-extension new-spec-path)))))
 
 (defun find-angular-project-root ()
   "Find the root directory of an Angular project."
@@ -355,7 +421,8 @@ Optionally SEARCH the angular.io website."
             (define-key map (kbd "C-c a j t") 'angular-jump-to-template)
             (define-key map (kbd "C-c a j v") 'angular-jump-to-stylesheet)
             (define-key map (kbd "C-c a j x") 'angular-jump-to-test)
-            (define-key map (kbd "C-c a r m") 'angular-refactor-move-component)
+            (define-key map (kbd "C-c a r d") 'angular-refactor-move-directory)
+            (define-key map (kbd "C-c a r e") 'angular-refactor-move-entity)
             map))
 
 (define-globalized-minor-mode global-angular-mode angular-mode

--- a/angular-mode.el
+++ b/angular-mode.el
@@ -24,6 +24,8 @@
 ;;   - C-c a j t: Jump to the associated component.html file.
 ;;   - C-c a j t: Jump to the associated component.(scss|sass|less|css) file.
 ;;   - C-c a j x: Jump to the associated component.spec.ts file.
+;;   - C-c a r d: Move a directory to a new destination and update import paths for all entities within the directory.
+;;   - C-c a r e: Move an entity and associated spec file to a new destination and update import paths for those files.
 ;;
 ;; To use this package, activate `angular-mode` and leverage the provided keybindings
 ;; to generate schematics in the project directory of choice.


### PR DESCRIPTION
Add support for moving files and directories within an Angular project. This provides an interactive way to move a directory of files or a specific file (and associated spec file) to a destination of choosing. Upon move, every import path that references the moved files will automatically update to the new path. By default, a relative path name will be used. There is a customize option called `angular-import-path-style` that can be set to absolute path instead.